### PR TITLE
Fixes #1 by passing SSL options to the phantomjs command.

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,11 +10,12 @@ var UrlToImage = (function() {
     api.render = function(url, file, opts) {
         opts = _.extend({
             width: 1280,
-            height: 800
+            height: 800,
+            ignoreSslErrors: true,
+            sslProtocol: 'any'
         }, opts);
 
         var def = Q.defer();
-
         var args = [
             path.join(__dirname, 'url-to-image.js'),
             url,
@@ -22,6 +23,33 @@ var UrlToImage = (function() {
             opts.width,
             opts.height
         ];
+        
+        /**
+         * Ignore SSL Errors.
+         *
+         * Takes true / false
+         */
+        if (opts.ignoreSslErrors) {
+          args.unshift('--ignore-ssl-errors');
+        }
+
+        if (opts.sslCertificatesPath) {
+          args.unshift('--ssl-certificates-path=' + opts.sslCertificatesPath);
+        }
+        
+        /**
+         * Set the SSL protocol to be used.
+         *
+         * Supported protocols:
+         * 
+         *   - sslv3
+         *   - sslv2
+         *   - tlsv1
+         *   - any
+         */
+        if (opts.sslProtocol) {
+          args.unshift('--ssl-protocol=' + opts.sslProtocol);
+        }
 
         var execOpts = {
             maxBuffer: Infinity


### PR DESCRIPTION
fixes #1 

Errors were a result of either an bad cert or a cert with a version other than sslv3.

Comand line options added are:
'--ssl-protocol=any'
'--ignore-ssl-errors=true'

These can be overriden from the options object passed to screenshot(url, filename, options).
where options = {ignoreSslErrors: true, sslProtocol: 'any'} by default.
