### PR TITLE
Add argument for ignore-ssl-errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ var UrlToImage = (function() {
          * Takes true / false
          */
         if (opts.ignoreSslErrors) {
-          args.unshift('--ignore-ssl-errors');
+          args.unshift('--ignore-ssl-errors=true');
         }
 
         if (opts.sslCertificatesPath) {


### PR DESCRIPTION
At least on Mac OS X, phantomjs 1.9.8 requires an argument:

``` shell
$ phantomjs --version
1.9.8
$ phantomjs --ignore-ssl-errors
Error: Option ignore-ssl-errors need a value
```
